### PR TITLE
GHCR.io image push - 8.*

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,7 +1,8 @@
 name: Build and Publish
 
 on: 
-  push:
+  push: 
+    branches: ['8.3']
   schedule:
     # High load times include the start of every hour.
     # If the load is sufficiently high enough, some queued jobs may be dropped.

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,6 @@ name: Build and Publish
 
 on: 
   push: 
-    #branches: ['8.3']
   schedule:
     # High load times include the start of every hour.
     # If the load is sufficiently high enough, some queued jobs may be dropped.

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Build and Publish
 
 on: 
   push: 
-    branches: ['8.3']
+    #branches: ['8.3']
   schedule:
     # High load times include the start of every hour.
     # If the load is sufficiently high enough, some queued jobs may be dropped.

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Build and Publish
 
 on: 
   push: 
-    branches: [ '8.1','8.3' ]
+    branches: [ '8.*' ]
   schedule:
     # High load times include the start of every hour.
     # If the load is sufficiently high enough, some queued jobs may be dropped.

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,6 +2,7 @@ name: Build and Publish
 
 on: 
   push: 
+    branches: [ '8.1','8.3' ]
   schedule:
     # High load times include the start of every hour.
     # If the load is sufficiently high enough, some queued jobs may be dropped.


### PR DESCRIPTION
Added
- Pushing the Docker images to ghcr.io (Git Container Registry)
- Also pushed in only 8.3, 8.1 branches