### PR TITLE
Update config-shim to 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY vhost.conf /etc/apache2/sites-enabled/
 
 RUN echo "ServerName 127.0.0.1" >> /etc/apache2/apache2.conf
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.2.1/config-shim.gz config-shim.gz
+ADD https://github.com/silinternational/config-shim/releases/download/v1.3.0/config-shim.gz config-shim.gz
 RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
 
 EXPOSE 80


### PR DESCRIPTION
Changes:
- Send all output to stderr
- Add a `fail` option (for if no parameters were received)

See https://github.com/silinternational/config-shim/releases for details.