### PR TITLE
Remove whenavail-script and netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y \
     libapache2-mod-php \
     locales \
     nano \
-    netcat-openbsd \
     php \
     php-cli \
     php-curl \
@@ -54,10 +53,6 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 # Install s3-expand
 ADD https://raw.githubusercontent.com/sil-org/s3-expand/master/s3-expand /usr/local/bin/s3-expand
 RUN chmod a+rx /usr/local/bin/s3-expand
-
-# Install whenavail
-ADD https://raw.githubusercontent.com/sil-org/whenavail-script/1.0.2/whenavail /usr/local/bin/whenavail
-RUN chmod a+rx /usr/local/bin/whenavail
 
 # Remove default site, configs, and mods not needed
 WORKDIR $HTTPD_PREFIX


### PR DESCRIPTION
### Removed
- Removed whenavail-script and netcat. These are no longer used. We instead use Docker Compose [healthcheck](https://docs.docker.com/reference/compose-file/services/#healthcheck).